### PR TITLE
Enable mobile access for Streamlit UI

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,4 @@
+[server]
+# Allow access from other devices on the network (e.g., smartphones)
+address = "0.0.0.0"
+port = 8501

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ MkDocs ナビゲーションへの追加（任意）:
 
 ## 簡易UI（Streamlit）
 - 起動: `uv run streamlit run ui/app.py`
+- スマホなど同じネットワーク上の端末からはブラウザで `http://<ホストPCのIP>:8501` にアクセス（`.streamlit/config.toml` で `server.address = "0.0.0.0"` を設定済み）
 - 機能: タグ/年で絞り込み、対象ノートを選択、タイトルとAbstract有無を指定してレビューMarkdownを生成・保存・ダウンロード
 - Abstract抽出を使う際は `ONEDRIVE_PAPERS_ROOT` を設定してローカルPDFを解決できるようにしてください。
 


### PR DESCRIPTION
## Summary
- Allow Streamlit to listen on all interfaces for access from phones or other devices.
- Document how to reach the UI from a smartphone on the same network.

## Testing
- `uv run python -m py_compile ui/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b30fd6f8e483278b6bd6f108f8dbf3